### PR TITLE
Spectrum index lookup table bug fix.

### DIFF
--- a/cascadia/depthcharge/data/spectrum_datasets.py
+++ b/cascadia/depthcharge/data/spectrum_datasets.py
@@ -140,14 +140,14 @@ class SpectrumDataset(Dataset):
             offsets.append(grp.attrs["n_spectra"])
             self._file_map[grp.attrs["path"]] = idx
 
-        self._file_offsets = np.cumsum([0] + offsets)
+        self._file_offsets = np.cumsum(offsets)
 
         # Build a map of 1D indices to 2D locations:
         grp_idx = 0
         for lin_idx in range(self._file_offsets[-1]):
             grp_idx += lin_idx >= self._file_offsets[grp_idx + 1]
             row_idx = lin_idx - self._file_offsets[grp_idx]
-            self._locs[lin_idx] = (grp_idx-1, row_idx)
+            self._locs[lin_idx] = (grp_idx, row_idx)
 
         self._offsets = None
         _ = self.offsets  # Reinitialize the offsets.


### PR DESCRIPTION
As kindly pointed out in #13, the code responsible for generating the spectrum index -> (file, file_index) lookup table behaves incorrectly if more than one file is used in a `SpectrumDataset`, since the original code would only index spectra up to the number of spectra in the last file in the dataset, because of the incorrect usage of `offsets` over `self._file_offsets`. 

There was an additional off by one error caused by adding two 0's to the beginning of the offset array instead of just one.